### PR TITLE
make workers option decimal integer

### DIFF
--- a/lib/rack/handler/right_speed.rb
+++ b/lib/rack/handler/right_speed.rb
@@ -11,7 +11,11 @@ module Rack
 
         host = options.delete(:Host) || default_host
         port = options.delete(:Port) || 8080
-        workers = options.delete(:Workers) || ::RightSpeed::Env.processors
+        workers = begin
+          Integer(options.delete(:Workers), 10)
+        rescue ArgumentError,TypeError
+          ::RightSpeed::Env.processors
+        end
         server = ::RightSpeed::Server.new(app: app, host: host, port: port, workers: workers)
 
         yield server if block_given?


### PR DESCRIPTION
```
~/src/right_speed (main)
git show --oneline | head -1
f06dbe6 simpler example
~/src/right_speed (main)
ruby --version
ruby 3.2.0 (2022-12-25 revision a528908271) [arm64-darwin22]
~/src/right_speed (main)
cat config.ru 
class MyApp
  def call(env)
    [
      200,
      {
        'Content-Type' => 'text/plain'
      },
      ["ok"],
    ]
  end
end

run MyApp.new
```

It is ok starting server without `-O Workers=8` option.

```
~/src/right_speed (main)
bundle exec rackup config.ru -s right_speed -p 8080             
[2022-12-31 21:03:33 +0900] INFO Start running with 8 workers
/Users/niku/src/right_speed/lib/right_speed/ractor_helper.rb:52: warning: already initialized constant Rack::ShowExceptions::TEMPLATE
/Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/rack-2.2.5/lib/rack/show_exceptions.rb:118: warning: previous definition of TEMPLATE was here
/Users/niku/src/right_speed/lib/right_speed/worker/roundrobin.rb:8: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
[2022-12-31 21:03:33 +0900] INFO listening localhost:8080
```

It failed starting server when adding `-O Workers=8` option.

```
~/src/right_speed (main)
bundle exec rackup config.ru -s right_speed -p 8080 -O Workers=8
[2022-12-31 20:59:19 +0900] INFO Start running with 8 workers
/Users/niku/src/right_speed/lib/right_speed/ractor_helper.rb:52: warning: already initialized constant Rack::ShowExceptions::TEMPLATE
/Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/rack-2.2.5/lib/rack/show_exceptions.rb:118: warning: previous definition of TEMPLATE was here
/Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/open3.rb:222:in `spawn': can't modify frozen IO: #<IO:<STDERR>> (FrozenError)
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/open3.rb:222:in `popen_run'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/open3.rb:103:in `popen3'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/open3.rb:290:in `capture3'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/source/git/git_proxy.rb:328:in `block in capture'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/shared_helpers.rb:70:in `with_clean_git_env'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/source/git/git_proxy.rb:326:in `capture'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/source/git/git_proxy.rb:244:in `git'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/source/git/git_proxy.rb:86:in `full_version'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/env.rb:78:in `git_version'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/env.rb:116:in `environment'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/env.rb:17:in `report'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/friendly_errors.rb:71:in `request_issue_report_for'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/friendly_errors.rb:50:in `log_error'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/friendly_errors.rb:123:in `rescue in with_friendly_errors'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/friendly_errors.rb:115:in `with_friendly_errors'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/libexec/bundle:33:in `<top (required)>'
        from /Users/niku/.asdf/installs/ruby/3.2.0/bin/bundle:25:in `load'
        from /Users/niku/.asdf/installs/ruby/3.2.0/bin/bundle:25:in `<main>'
/Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/ui/shell.rb:136:in `tty?': can't modify frozen IO: #<IO:<STDERR>> (FrozenError)
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/ui/shell.rb:136:in `tell_err'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/ui/shell.rb:46:in `error'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/cli/exec.rb:62:in `rescue in kernel_load'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/cli/exec.rb:51:in `kernel_load'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/cli/exec.rb:23:in `run'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/cli.rb:491:in `exec'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/cli.rb:34:in `dispatch'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/cli.rb:28:in `start'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/libexec/bundle:45:in `block in <top (required)>'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/libexec/bundle:33:in `<top (required)>'
        from /Users/niku/.asdf/installs/ruby/3.2.0/bin/bundle:25:in `load'
        from /Users/niku/.asdf/installs/ruby/3.2.0/bin/bundle:25:in `<main>'
/Users/niku/src/right_speed/lib/right_speed/processor.rb:73:in `initialize': undefined method `times' for "8":String (NoMethodError)

        @workers = workers.times.map{|i| Worker::RoundRobin.new(id: i, handler: @handler)}
                          ^^^^^^
        from /Users/niku/src/right_speed/lib/right_speed/processor.rb:23:in `new'
        from /Users/niku/src/right_speed/lib/right_speed/processor.rb:23:in `setup'
        from /Users/niku/src/right_speed/lib/right_speed/server.rb:58:in `run'
        from /Users/niku/src/right_speed/lib/rack/handler/right_speed.rb:19:in `run'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/rack-2.2.5/lib/rack/server.rb:327:in `start'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/rack-2.2.5/lib/rack/server.rb:168:in `start'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/rack-2.2.5/bin/rackup:5:in `<top (required)>'
        from /Users/niku/.asdf/installs/ruby/3.2.0/bin/rackup:25:in `load'
        from /Users/niku/.asdf/installs/ruby/3.2.0/bin/rackup:25:in `<top (required)>'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `load'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/cli/exec.rb:58:in `kernel_load'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/cli/exec.rb:23:in `run'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/cli.rb:491:in `exec'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/cli.rb:34:in `dispatch'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/cli.rb:28:in `start'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/libexec/bundle:45:in `block in <top (required)>'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/3.2.0/bundler/friendly_errors.rb:117:in `with_friendly_errors'
        from /Users/niku/.asdf/installs/ruby/3.2.0/lib/ruby/gems/3.2.0/gems/bundler-2.4.1/libexec/bundle:33:in `<top (required)>'
        from /Users/niku/.asdf/installs/ruby/3.2.0/bin/bundle:25:in `load'
        from /Users/niku/.asdf/installs/ruby/3.2.0/bin/bundle:25:in `<main>'
```
